### PR TITLE
Updating documentation to reflect recent changes in the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ encoded string. The SDK API also contains a `VaultSecret` `@dataclass` containin
 a the Secret's attributes. The `data` attribute is a Python Dictionary.
 
 ```python
-from thycotic.secrets.dataclasses import Secret
+from thycotic.secrets.vault import VaultSecret
 
 secret = VaultSecret(**vault.get_secret("/test/secret"))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ chardet==3.0.4
 idna==2.8
 requests==2.22.0
 urllib3==1.25.8
+pytest


### PR DESCRIPTION
This PR addresses two issues:

1. In commit `42023ef8c8a3869a2a01d2def7e1dd41f3e57b9b`, the `dataclass.py` file was removed and the main dataclass was renamed to `VaultSecret`. This change was not reflected in the documentation. 

2. `pytest` is required for local build and testing. It is not listed in the `requirements.txt` file. This was added in this PR. 